### PR TITLE
Bunch of fixes and improvements over the base_geoengine migration to 17.0

### DIFF
--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -30,7 +30,7 @@
             ("include", "web._assets_bootstrap"),
         ]
     },
-    "external_dependencies": {"python": ["shapely", "geojson", "simplejson"]},
+    "external_dependencies": {"python": ["shapely", "geojson"]},
     "installable": True,
     "pre_init_hook": "init_postgis",
 }

--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -10,7 +10,7 @@ from odoo import _, fields
 from odoo.tools import sql
 
 from . import geo_convertion_helper as convert
-from .geo_db import create_geo_column
+from .geo_db import create_geo_column, create_geo_index
 
 logger = logging.getLogger(__name__)
 try:
@@ -158,14 +158,7 @@ class GeoField(fields.Field):
                 )
             )
         if self.gist_index:
-            cr.execute(
-                "SELECT indexname FROM pg_indexes WHERE indexname = %s",
-                (self._postgis_index_name(model._table, self.name),),
-            )
-            index = cr.fetchone()
-            if index:
-                return True
-            self._create_index(cr, model._table, self.name)
+            create_geo_index(cr, self.name, model._table)
         return True
 
     def update_db_column(self, model, column):
@@ -189,9 +182,13 @@ class GeoField(fields.Field):
                 self.dim,
                 self.string,
             )
+            if self.gist_index:
+                create_geo_index(model._cr, self.name, model._table)
             return
 
         if column["udt_name"] == self.column_type[0]:
+            if self.gist_index:
+                create_geo_index(model._cr, self.name, model._table)
             return
 
         self.update_geo_db_column(model)

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -58,7 +58,7 @@ export class GeoengineController extends Component {
             this.props.fields
         );
 
-        const modelConfig = this.props.state.modelState.config || {
+        const modelConfig = this.props.state?.modelState.config || {
             resModel: resModel,
             fields,
             activeFields,
@@ -67,7 +67,7 @@ export class GeoengineController extends Component {
 
         return {
             config: modelConfig,
-            state: this.props.state.modelState,
+            state: this.props.state?.modelState,
             limit: archInfo.limit || limit,
             countLimit: archInfo.countLimit,
             defaultOrderBy: archInfo.defaultOrder,

--- a/base_geoengine/static/src/js/views/geoengine/layers_panel/layers_panel.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/layers_panel/layers_panel.esm.js
@@ -11,8 +11,9 @@ import {vectorLayersStore} from "../../../vector_layers_store.esm";
 import {useOwnedDialogs, useService} from "@web/core/utils/hooks";
 import {DomainSelectorGeoFieldDialog} from "../../../widgets/domain_selector_geo_field/domain_selector_geo_field_dialog/domain_selector_geo_field_dialog.esm";
 import {FormViewDialog} from "@web/views/view_dialogs/form_view_dialog";
+import {useSortable} from "@web/core/utils/sortable_owl";
 
-import {Component, onWillStart, useState} from "@odoo/owl";
+import {Component, onWillStart, useState, useRef} from "@odoo/owl";
 
 export class LayersPanel extends Component {
     setup() {
@@ -48,10 +49,27 @@ export class LayersPanel extends Component {
         /**
          * Allows you to change the priority of the layer by sliding them over each other
          */
+        let dataRowId = "";
+        useSortable({
+            ref: useRef("root"),
+            elements: ".item",
+            handle: ".fa-sort",
+            onDragStart: (params) => {
+                const { element } = params;
+                dataRowId = element.dataset.id;
+                this.sortStart(params);
+            },
+            onDragEnd: (params) => this.sortStop(params),
+            onDrop: (params) => this.sort(dataRowId, params),
+        });
     }
 
     sortStart({element}) {
         element.classList.add("shadow");
+    }
+
+    sortStop({element}) {
+        element.classList.remove("shadow");
     }
 
     async loadIsAdmin() {

--- a/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_field.esm.js
+++ b/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_field.esm.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import {DomainField} from "@web/views/fields/domain/domain_field";
+import {domainField, DomainField} from "@web/views/fields/domain/domain_field";
 import {registry} from "@web/core/registry";
 
 export class DomainFieldExtend extends DomainField {
@@ -31,4 +31,4 @@ export class DomainFieldExtend extends DomainField {
     }
 }
 
-registry.category("fields").add("domain", DomainFieldExtend, {force: true});
+domainField.component = DomainFieldExtend;

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -140,8 +140,7 @@ export class FieldGeoEngineEditMap extends Component {
             if (this.displayValue == value) return;
             this.displayValue = value;
             var ft = new ol.Feature({
-                geometry: new ol.format.GeoJSON().readGeometry(value),
-                labelPoint: new ol.format.GeoJSON().readGeometry(value),
+                geometry: this.format.readGeometry(value)
             });
             this.source.clear();
             this.source.addFeature(ft);
@@ -250,8 +249,8 @@ export class FieldGeoEngineEditMap extends Component {
         });
         this.map.addLayer(this.vectorLayer);
         this.format = new ol.format.GeoJSON({
-            internalProjection: this.map.getView().getProjection(),
-            externalProjection: "EPSG:" + this.srid,
+            featureProjection: this.map.getView().getProjection(),
+            dataProjection: "EPSG:" + this.srid,
         });
 
         if (!this.props.readonly) {

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -317,26 +317,32 @@ export class FieldGeoEngineEditMapMultiLine extends FieldGeoEngineEditMap {
 
 export const fieldGeoEngineEditMapMultiPolygon = {
     component: FieldGeoEngineEditMapMultiPolygon,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 export const fieldGeoEngineEditMapPolygon = {
     component: FieldGeoEngineEditMapPolygon,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 export const fieldGeoEngineEditMapPoint = {
     component: FieldGeoEngineEditMapPoint,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 export const fieldGeoEngineEditMapMultiPoint = {
     component: FieldGeoEngineEditMapMultiPoint,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 export const fieldGeoEngineEditMapLine = {
     component: FieldGeoEngineEditMapLine,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 export const fieldGeoEngineEditMapMultiLine = {
     component: FieldGeoEngineEditMapMultiLine,
+    extractProps: (attrs) => FieldGeoEngineEditMap.extractProps(attrs),
 };
 
 registry.category("fields").add("geo_multi_polygon", fieldGeoEngineEditMapMultiPolygon);

--- a/base_geoengine/views/geo_vector_layer_view.xml
+++ b/base_geoengine/views/geo_vector_layer_view.xml
@@ -25,7 +25,7 @@
                         <field name="model_id" />
                         <field
                             name="model_view_id"
-                            domain="[('mode', '=', 'geoengine')]"
+                            domain="[('type', '=', 'geoengine')]"
                         />
                         <field name="model_name" invisible="1" />
                         <field

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
 geojson
 shapely
-simplejson


### PR DESCRIPTION
After having been reviewing your code proposal for base_geoengine, here are some commits to correct certain things that I have detected:

- Fix in the component override in domain field
- Field 'type' is used instead of 'mode' in model_view_id domain in vector layer view
- Removes 'simplejson' as a python dependency
- Completes the layers panel reordering by drag and drop
- Fix in the access to props state that can be undefined in controller modelParams
- Recovers the gist index creation for geometry columns when is required
- Adds correction on the configuration and use of projections in widget geometry
- Fixes the use of extractProps in geometry fields