### PR TITLE
Adds 't-name' as an allowed owl directive when templated popup is compiled

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_compiler.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_compiler.esm.js
@@ -7,3 +7,8 @@
 import {ViewCompiler} from "@web/views/view_compiler";
 
 export class GeoengineCompiler extends ViewCompiler {}
+
+GeoengineCompiler.OWL_DIRECTIVE_WHITELIST = [
+    ...ViewCompiler.OWL_DIRECTIVE_WHITELIST,
+    "t-name",
+];


### PR DESCRIPTION
When the popup is about to show up, the view compiler tests if all owl directives used in the template are permitted or not. OWL_DIRECTIVE_WHITELIST has to include 't-name' in order to pass this test and not show a warning on the javascript console.