### PR TITLE
Uses props id instead of date timespan for better uniqueness of widget id

### DIFF
--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -14,7 +14,7 @@ import {Component, onMounted, onRendered, onWillStart, useEffect} from "@odoo/ow
 export class FieldGeoEngineEditMap extends Component {
     setup() {
         // Allows you to have a unique id if you put the same field in the view several times
-        this.id = `map_${Date.now()}`;
+        this.id = `map_${this.props.id}`;
         this.orm = useService("orm");
 
         onWillStart(() =>


### PR DESCRIPTION
The 'this.props.id' is managed by owl and seems enough to be a unique id.