### PR TITLE
Correctly defines the default dim as string

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -30,7 +30,7 @@ class GeoField(fields.Field):
     """
 
     geo_type = None
-    dim = 2
+    dim = "2"
     srid = 3857
     gist_index = True
 


### PR DESCRIPTION
Correctly defines the default dim as string cause a selection has to be string since Odoo 13.