### PR TITLE
Fix geo type selection

### DIFF
--- a/base_geoengine/i18n/base_geoengine.pot
+++ b/base_geoengine/i18n/base_geoengine.pot
@@ -294,7 +294,7 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__linestring
-msgid "LINESTRING"
+msgid "LineString"
 msgstr ""
 
 #. module: base_geoengine
@@ -373,17 +373,17 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multilinestring
-msgid "MULTILINESTRING"
+msgid "MultiLineString"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipoint
-msgid "MULTIPOINT"
+msgid "MultiPoint"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipolygon
-msgid "MULTIPOLYGON"
+msgid "MultiPolygon"
 msgstr ""
 
 #. module: base_geoengine
@@ -488,12 +488,12 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__point
-msgid "POINT"
+msgid "Point"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__polygon
-msgid "POLYGON"
+msgid "Polygon"
 msgstr ""
 
 #. module: base_geoengine

--- a/base_geoengine/i18n/es.po
+++ b/base_geoengine/i18n/es.po
@@ -314,8 +314,8 @@ msgstr "¿Es una capa de superposición?"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__linestring
-msgid "LINESTRING"
-msgstr "SECUENCIA DE LÍNEAS"
+msgid "LineString"
+msgstr "Secuencia de líneas"
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer____last_update
@@ -393,18 +393,18 @@ msgstr "Lista de dimensiones separadas por ','"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multilinestring
-msgid "MULTILINESTRING"
-msgstr "CADENA MULTILÍNEA"
+msgid "MultiLineString"
+msgstr "Cadena multilínea"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipoint
-msgid "MULTIPOINT"
-msgstr "PUNTO MÚLTIPLE"
+msgid "MultiPoint"
+msgstr "Punto Múltiple"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipolygon
-msgid "MULTIPOLYGON"
-msgstr "MULTIPOLÍGONO"
+msgid "MultiPolygon"
+msgstr "Multipolígono"
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__matrix_set
@@ -508,13 +508,13 @@ msgstr "OpenStreetMap"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__point
-msgid "POINT"
-msgstr "PUNTO"
+msgid "Point"
+msgstr "Punto"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__polygon
-msgid "POLYGON"
-msgstr "POLÍGONO"
+msgid "Polygon"
+msgstr "Polígono"
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params

--- a/base_geoengine/i18n/fr_BE.po
+++ b/base_geoengine/i18n/fr_BE.po
@@ -315,7 +315,7 @@ msgstr "S'agit-il d'une couche superposée ?"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__linestring
-msgid "LINESTRING"
+msgid "LineString"
 msgstr ""
 
 #. module: base_geoengine
@@ -394,17 +394,17 @@ msgstr "Liste des dimensions séparées par ','"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multilinestring
-msgid "MULTILINESTRING"
+msgid "MultiLineString"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipoint
-msgid "MULTIPOINT"
+msgid "MultiPoint"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipolygon
-msgid "MULTIPOLYGON"
+msgid "MultiPolygon"
 msgstr ""
 
 #. module: base_geoengine
@@ -509,12 +509,12 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__point
-msgid "POINT"
+msgid "Point"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__polygon
-msgid "POLYGON"
+msgid "Polygon"
 msgstr ""
 
 #. module: base_geoengine

--- a/base_geoengine/i18n/it.po
+++ b/base_geoengine/i18n/it.po
@@ -311,8 +311,8 @@ msgstr "È livello in sovraimpressione?"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__linestring
-msgid "LINESTRING"
-msgstr "LINESTRING"
+msgid "LineString"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer____last_update
@@ -390,18 +390,18 @@ msgstr "Elenco dimensioni separate da ','"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multilinestring
-msgid "MULTILINESTRING"
-msgstr "MULTILINESTRING"
+msgid "MultiLineString"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipoint
-msgid "MULTIPOINT"
-msgstr "MULTIPOINT"
+msgid "MultiPoint"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipolygon
-msgid "MULTIPOLYGON"
-msgstr "MULTIPOLYGON"
+msgid "MultiPolygon"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__matrix_set
@@ -505,13 +505,13 @@ msgstr "OpenStreetMap"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__point
-msgid "POINT"
-msgstr "POINT"
+msgid "Point"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__polygon
-msgid "POLYGON"
-msgstr "POLYGON"
+msgid "Polygon"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params

--- a/base_geoengine/i18n/sv.po
+++ b/base_geoengine/i18n/sv.po
@@ -309,8 +309,8 @@ msgstr "Är överläggslager?"
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__linestring
 #, fuzzy
-msgid "LINESTRING"
-msgstr "LINESTRING"
+msgid "LineString"
+msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer____last_update
@@ -388,17 +388,17 @@ msgstr "Lista över dimensioner avgränsade med ','"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multilinestring
-msgid "MULTILINESTRING"
+msgid "MultiLineString"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipoint
-msgid "MULTIPOINT"
+msgid "MultiPoint"
 msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__multipolygon
-msgid "MULTIPOLYGON"
+msgid "MultiPolygon"
 msgstr ""
 
 #. module: base_geoengine
@@ -503,12 +503,12 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__point
-msgid "POINT"
-msgstr "PEKA"
+msgid "Point"
+msgstr "Peka"
 
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__ir_model_fields__geo_type__polygon
-msgid "POLYGON"
+msgid "Polygon"
 msgstr ""
 
 #. module: base_geoengine

--- a/base_geoengine/models/ir_model.py
+++ b/base_geoengine/models/ir_model.py
@@ -27,12 +27,12 @@ GEO_TYPES_ONDELETE = {
 }
 
 POSTGIS_GEO_TYPES = [
-    ("POINT", "POINT"),
-    ("MULTIPOINT", "MULTIPOINT"),
-    ("LINESTRING", "LINESTRING"),
-    ("MULTILINESTRING", "MULTILINESTRING"),
-    ("POLYGON", "POLYGON"),
-    ("MULTIPOLYGON", "MULTIPOLYGON"),
+    ("Point", "Point"),
+    ("MultiPoint", "MultiPoint"),
+    ("LineString", "LineString"),
+    ("MultiLineString", "MultiLineString"),
+    ("Polygon", "Polygon"),
+    ("MultiPolygon", "MultiPolygon"),
 ]
 
 


### PR DESCRIPTION
Hi @peluko00 and @miquelalzanillas, could you consider incorporating this minor fix?

The 'POSTGIS_GEO_TYPES' enumeration still uses obsolete names for geo_type in capital letters. Those names are now UpperCamelCase.