### PR TITLE
Adds ordering on raster layers

### DIFF
--- a/base_geoengine/models/geo_raster_layer.py
+++ b/base_geoengine/models/geo_raster_layer.py
@@ -17,6 +17,7 @@ class GeoRasterLayerType(models.Model):
 class GeoRasterLayer(models.Model):
     _name = "geoengine.raster.layer"
     _description = "Raster Layer"
+    _order = "sequence ASC, name"
 
     raster_type = fields.Selection(
         [


### PR DESCRIPTION
Raster layers are currently listed based on creation id. This commit specifies an ordering similar to what is defined in vector layers, ordering by sequence and name.