### PR TITLE
Fix of two warnings

### DIFF
--- a/base_geoengine/i18n/base_geoengine.pot
+++ b/base_geoengine/i18n/base_geoengine.pot
@@ -498,7 +498,7 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params
-#: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params_wms
+#: model_terms:ir.ui.view,arch_db:base_geoengine.geo_raster_view_form
 msgid "Params"
 msgstr ""
 

--- a/base_geoengine/i18n/es.po
+++ b/base_geoengine/i18n/es.po
@@ -518,7 +518,7 @@ msgstr "Polígono"
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params
-#: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params_wms
+#: model_terms:ir.ui.view,arch_db:base_geoengine.geo_raster_view_form
 msgid "Params"
 msgstr "Parámetros"
 

--- a/base_geoengine/i18n/fr_BE.po
+++ b/base_geoengine/i18n/fr_BE.po
@@ -519,7 +519,7 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params
-#: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params_wms
+#: model_terms:ir.ui.view,arch_db:base_geoengine.geo_raster_view_form
 msgid "Params"
 msgstr "Paramètres"
 

--- a/base_geoengine/i18n/it.po
+++ b/base_geoengine/i18n/it.po
@@ -515,7 +515,7 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params
-#: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params_wms
+#: model_terms:ir.ui.view,arch_db:base_geoengine.geo_raster_view_form
 msgid "Params"
 msgstr "Parametri"
 

--- a/base_geoengine/i18n/sv.po
+++ b/base_geoengine/i18n/sv.po
@@ -513,7 +513,7 @@ msgstr ""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params
-#: model:ir.model.fields,field_description:base_geoengine.field_geoengine_raster_layer__params_wms
+#: model_terms:ir.ui.view,arch_db:base_geoengine.geo_raster_view_form
 msgid "Params"
 msgstr ""
 

--- a/base_geoengine/models/geo_raster_layer.py
+++ b/base_geoengine/models/geo_raster_layer.py
@@ -49,7 +49,7 @@ class GeoRasterLayer(models.Model):
     params = fields.Char(help="Dictiorary of values for dimensions as JSON")
 
     # wms options
-    params_wms = fields.Char("Params", help="Need to provide at least a LAYERS param")
+    params_wms = fields.Char(help="Need to provide at least a LAYERS param")
     server_type = fields.Char(
         help="The type of the remote WMS server: mapserver, \
             geoserver, carmentaserver, or qgis",

--- a/base_geoengine/static/description/index.html
+++ b/base_geoengine/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/base_geoengine/views/geo_raster_layer_view.xml
+++ b/base_geoengine/views/geo_raster_layer_view.xml
@@ -37,7 +37,7 @@
                     </group>
                     <field name="is_wms" invisible="1" />
                     <group string="WMS options" invisible="not is_wms" colspan="4">
-                        <field name="params_wms" required="is_wms" />
+                        <field name="params_wms" required="is_wms" string="Params" />
                         <field name="server_type" required="is_wms" />
                     </group>
                     <field name="has_type" invisible="1" />


### PR DESCRIPTION
This pull request adds fixes to two warnings in odoo 17:

- Same label in two of the raster fields: params, params_wms.
- An xml declaration in first line of html description is obsolete.